### PR TITLE
fix: Drop print items using the loot builder/context

### DIFF
--- a/src/generated/resources/data/sc-peripherals/loot_tables/blocks/print.json
+++ b/src/generated/resources/data/sc-peripherals/loot_tables/blocks/print.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:dynamic",
+          "name": "sc-peripherals:print"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/kotlin/io/sc3/peripherals/datagen/BlockLootTableProvider.kt
+++ b/src/main/kotlin/io/sc3/peripherals/datagen/BlockLootTableProvider.kt
@@ -1,11 +1,26 @@
 package io.sc3.peripherals.datagen
 
 import io.sc3.peripherals.Registration.ModBlocks
+import io.sc3.peripherals.prints.PrintBlock
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootTableProvider
+import net.minecraft.loot.LootPool
+import net.minecraft.loot.LootTable
+import net.minecraft.loot.entry.DynamicEntry
+import net.minecraft.loot.provider.number.ConstantLootNumberProvider
 
 class BlockLootTableProvider(out: FabricDataOutput) : FabricBlockLootTableProvider(out) {
   override fun generate() {
     addDrop(ModBlocks.printer)
+    addDrop(
+      ModBlocks.print, LootTable.builder().pool(
+        addSurvivesExplosionCondition(
+          ModBlocks.print,
+          LootPool.builder()
+            .rolls(ConstantLootNumberProvider.create(1.0F))
+            .with(DynamicEntry.builder(PrintBlock.dropId))
+        )
+      )
+    );
   }
 }

--- a/src/main/kotlin/io/sc3/peripherals/prints/PrintBlock.kt
+++ b/src/main/kotlin/io/sc3/peripherals/prints/PrintBlock.kt
@@ -78,13 +78,12 @@ class PrintBlock(settings: Settings) : BaseBlockWithEntity(settings), Waterlogga
   }
 
   override fun getDroppedStacks(state: BlockState, builder: LootContext.Builder): MutableList<ItemStack> {
-    val stacks = super.getDroppedStacks(state, builder)
+    val be = builder.get(LootContextParameters.BLOCK_ENTITY)
+    if(be is PrintBlockEntity) {
+      builder.putDrop(dropId) { _, consumer -> consumer.accept(PrintItem.fromBlockEntity(be)) }
+    }
 
-    val pos = BlockPos(builder.get(LootContextParameters.ORIGIN))
-    val be = blockEntity(builder.world, pos) ?: return stacks
-    stacks.add(PrintItem.fromBlockEntity(be))
-
-    return stacks
+    return super.getDroppedStacks(state, builder)
   }
 
   // Shapes - outline and collision
@@ -162,6 +161,8 @@ class PrintBlock(settings: Settings) : BaseBlockWithEntity(settings), Waterlogga
 
   companion object {
     val id = ModId("block/print")
+
+    val dropId = ModId("print")
 
     val facing: DirectionProperty = Properties.HORIZONTAL_FACING
     val on: BooleanProperty = BooleanProperty.of("on")


### PR DESCRIPTION
Turns out there was a reason for 771014a1e380947611862a359f9663ff8f80f012 !