### PR TITLE
feat: .2dja support for poster.lua

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/programs/poster.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/poster.lua
@@ -1,94 +1,180 @@
-local startColor = term.getTextColor()
+local startTColor = term.getTextColor()
 
 local function printUsage()
   local programName = arg[0] or fs.getName(shell.getRunningProgram())
-  print("Usage: ")
-  print(programName .. " <file.2dj or url> [count]")
-  print(programName .. " stop")
+  
+  term.setTextColor(colors.lightGray)
+  term.write("Usage: ")
+
+  term.setTextColor(colors.white)
+  print(("%s <file or url> [count] [options?]"):format(programName))
+  
+  term.setTextColor(colors.gray)
+  print("Options for .2dja: [ <index> | <from> <to> ]")
+  
+  term.setTextColor(colors.white)
+  print(("Type '%s stop' to cancel the print task"):format(programName))
 end
 
 -- Find a printer
 local printer = peripheral.find("poster_printer")
 if not printer then
-  error("No printer found", 0)
+  error("No printer found.", 0)
 end
 
 -- Validate arguments
-local args = { ... }
-if #args < 1 or #args > 2 then
+local tArgs = { ... }
+if #tArgs < 1 or #tArgs > 4
+or tArgs[1]:lower() == "help" then
   printUsage()
   return
 end
 
 -- Stop the printer by running `poster stop`
-if args[1] == "stop" then
+if tArgs[1] == "stop" then
   print("Stopping printer...")
   printer.stop()
   return
 end
 
-local count = 1
-if #args == 2 then
-  count = tonumber(args[2])
-  if not count or math.floor(count) < 1 then
+local status = printer.status()
+if status == "busy" then
+  error("Printer is busy.", 0)
+end
+
+-- Convert string to number and validate it.
+local function getNum(str)
+  local num = tonumber(str)
+  if not num or math.floor(num) < 1 then
+    return
+  end
+  return math.floor(num)
+end
+
+-- Get count.
+local nCount = 1
+if #tArgs > 1 then
+  nCount = getNum(tArgs[2])
+  if not nCount then
     printUsage()
     return
   end
-  count = math.floor(count)
 end
 
--- Load the 2dj file
-local filename = args[1]
-
-local function load2djFile(name)
-  local f
-  if http and name:match("^https?://") then
-    print("Downloading...")
-    f = http.get{ url = name, binary = true }
-  else
-    name = shell.resolve(name)
-    if not fs.exists(name) then
-      -- Try to find a .2dj file if the user didn't specify the extension
-      if not filename:match(".2dj$") then
-        local newName = name .. ".2dj"
-        if fs.exists(newName) then
-          return load2djFile(newName)
-        end
-      end
-      error("File not found: " .. name, 0)
-    end
-    f = fs.open(name, "r")
+-- Get index, if given.
+local tIndex = { bAll = true, from = nil, to = nil }
+if #tArgs >= 3 then
+  local num1,num2 = getNum(tArgs[3]), getNum(tArgs[4])
+  if not num1 or not num2 then
+    printUsage()
+    return
   end
   
-  if not f then
-    error("Could not open " .. name, 0)
+  tIndex.from = math.min(num1,num2)
+  tIndex.to = math.max(num1,num2)
+  
+  -- Index, not interval
+  if not tIndex.to then
+    tIndex.to = tIndex.from
   end
-  local data = f.readAll()
-  f.close()
+  
+  if tIndex.from then
+    tIndex.bAll = false
+  end
+end
 
-  local data, err = textutils.unserialiseJSON(data)
-  if data == nil then
-    error("\n\nCould not parse " .. name .. ": " .. err, 0)
+local sFilename = tArgs[1]
+-- Loads from local file or Url
+local function loadPoster(sName)
+  local stream
+
+  if http and sName:match("^https?://") then
+    print("Downloading...")
+    stream = http.get{ url = sName, binary = true }
+  else
+    print("Loading...")
+    sName = shell.resolve(sName)
+    if not fs.exists(sName) then
+      -- Try to find a .2dj or .2dja file if the extension did not got specified 
+      if not sFilename:match(".2dj$") or not sFilename:match(".2dja$") then
+        for _,sEnd in ipairs({".2dj", ".2dja"}) do
+          local newName = sName..sEnd
+          if fs.exists(newName) then
+            return loadPoster(newName)
+          end
+        end
+      end
+      error(("File \'%s\' not found."):format(sName), 0)
+    end
+    stream = fs.open(sName, "r")
+  end
+  
+  if not stream then
+    error(("Could not open \'%s\'."):format(sName), 0)
+  end
+
+  local data = stream.readAll()
+  stream.close()
+
+  local data,err = textutils.unserialiseJSON(data)
+  if type(data) ~= "table" then
+    error(("\n\nCould not parse \'%s\': %s"):format(sName,err), 0)
   end
   return data
 end
 
-local printData = load2djFile(filename)
-if not printData.pixels then
-  error("Invalid print data - missing pixels")
+-- Check if given poster is valid
+local function validPoster(data)
+  if type(data.pixels) ~= "table" then
+    return true, "Table \'pixels\' does not exist."
+  elseif type(data.palette) ~= "table" then
+    return true, "Table \'palette\' does not exist."
+  end
+
+  return false
 end
 
--- Output some basic print metadata (models often have credit in tooltips)
-term.write("Printing: ")
-term.setTextColor(colors.lightGray)
-print(printData.label or filename)
+local tPosters = {}
+local data = loadPoster(sFilename)
+-- Add all needed pages to stack (.2dja)
+if type(data.pages) == "table" then
+  if tIndex.bAll then
+    tIndex.from = 1
+    tIndex.to = #data.pages
+  end
 
-if printData.tooltip then
-  term.write(printData.tooltip)
+  for i=tIndex.from, tIndex.to do
+    local poster = data.pages[i]
+    local bError, sMsg = validPoster(poster)
+    if bError then
+      error(("Could not load page %s: %s"):format(i, sMsg), 0)
+    end
+
+    table.insert(tPosters, poster)
+  end
+else
+  -- Add poster to stack x nCounter (.2dj)
+  local bError, sMsg = validPoster(data)
+  if bError then
+    error(("Could not load .2dj file: %s"):format(sMsg), 0)
+  end
+  table.insert(tPosters, data)
 end
 
-print("")
+-- Setup colors
+local nHighlightColor = colors.lightGray
+local nErrColor = colors.gray
+local nGreenColor = colors.white
 
+if term.isColor() then
+  nHighlightColor = colors.yellow
+  nErrColor = colors.red
+  nGreenColor = colors.green
+end
+
+
+
+-- Print a given poster
 local function commitPrint(data)
   printer.reset()
 
@@ -98,85 +184,90 @@ local function commitPrint(data)
   printer.blitPalette(data.palette)
   printer.blitPixels(1, 1, data.pixels)
 
-  printer.commit(count)
+  printer.commit(nCount)
 end
 
-local function percent(n, m)
-  return math.ceil(n / m * 100)
-end
-
-local function writePercent(label, n, m)
-  local level = percent(n, m)
-
-  term.setTextColor(colors.yellow)
-  term.write(label)
-  
-  term.setTextColor(level >= 10 and colors.white or colors.red)
-  term.write(level .. "%  ")
-end
-
-local remaining = count
-local function showPrintStatus()
-  local _, y = term.getCursorPos()
-  local ink, maxInk = printer.getInkLevel()
-
-  term.setCursorPos(1, y - 1)
-  term.clearLine()
-  writePercent("Ink: ", ink, maxInk)
-  
-  term.setCursorPos(1, y)
-  term.clearLine()
-  term.setTextColor(colors.yellow)
-  term.write("Printing... ")
-  term.setTextColor(colors.white)
-  term.write(math.min((count - remaining) + 1, count) .. " / " .. count)
-
-  term.setCursorPos(1, y)
-end
-
--- Begin printing
-local status = printer.status()
-if status == "busy" then
-  error("Printer is busy", 0)
-end
-
-commitPrint(printData)
-
-term.setTextColor(colors.yellow)
+-- Start printing (Finally...)
+term.setTextColor(nHighlightColor)
 print("\nHold Ctrl+T to stop\n")
-showPrintStatus()
 
-while true do
-  local e, p1 = os.pullEventRaw()
-  local n = math.min(math.max((count - remaining) + 1, 1), count)
+term.setTextColor(colors.lightGray)
+print("Now printing:")
 
-  if e == "poster_printer_complete" or e == "poster_printer_state" then
-    remaining = p1
-    showPrintStatus()
+local _,nY = term.getCursorPos()
+local nW,_ = term.getSize()
 
-    if remaining <= 0 then
-      -- Printing complete, print the count we managed to print
-      local _, y = term.getCursorPos()
-      term.setCursorPos(1, y)
-      term.clearLine()
-      term.setTextColor(colors.green)
-      print("Printed " .. n .. " item" .. (n ~= 1 and "s" or ""))
+-- Move everything up for enough space
+if nY > 16 then
+  term.scroll(4)
+  nY = 15
+end
 
-      break
-    end
-  elseif e == "terminate" then    
-    -- Halt printing and print the count we managed to print
-    printer.stop()
-
-    local _, y = term.getCursorPos()
-    term.setCursorPos(1, y)
-    term.clearLine()
-    term.setTextColor(colors.red)
-    print("Printing terminated. Printed " .. n .. " item" .. 
-      (n ~= 1 and "s" or "") .. " out of " .. count)
-
-    break 
+local function printRow(sName, sValue, sOptional)
+  term.setTextColor(nHighlightColor)
+  term.write(sName)
+  term.setTextColor(colors.white)
+  term.write(sValue)
+  if sOptional then
+    term.setTextColor(colors.lightGray)
+    term.write(sOptional)
   end
 end
 
-term.setTextColor(startColor)
+-- Loop to print all selected posters
+local nPrinted = 0
+local nMaxPages = #tPosters*nCount
+local bTerminated = false
+
+for i,data in ipairs(tPosters) do
+  local nCur = 0
+  if bTerminated then break end
+  commitPrint(data)
+  
+  term.setCursorPos(1,nY)
+  printRow("Name: ", (data.label or "???"):sub(1,nW-6))
+  
+  term.setCursorPos(1,nY+1)
+  printRow("Status: ", (" %s%% : %s / %s "):format(0, nPrinted, nMaxPages), (" (x%s)       "):format(nCount))
+
+
+  local cur,max = printer.getInkLevel()
+  term.setCursorPos(1,nY+2)
+  printRow("Ink: ", (" %s%%   "):format(math.floor(100/max*cur)))
+  
+  -- Status and Ink level
+  while true do
+    local e, p1 = os.pullEventRaw()
+    
+    if e == "poster_printer_complete" or e == "poster_printer_state" then
+      local progress = 100-(tonumber(p1) or 0)
+      
+      if progress >= 100 then
+        nPrinted = nPrinted+1
+        nCur = nCur+1
+      end
+
+      term.setCursorPos(1,nY+1)
+      printRow("Status: ", (" %s%% : %s / %s "):format(progress, nPrinted, nMaxPages), (" (x%s)       "):format(nCount))
+      
+      if nCur >= nCount then
+        break
+      end
+    elseif e == "terminate" then
+      printer.stop()
+      bTerminated = true
+      break
+    end
+  end
+end
+
+-- Print results
+term.setCursorPos(1, nY+3)
+if bTerminated then
+  term.setTextColor(nErrColor)
+  print(("Printed %s posters out of %s."):format(nPrinted+1, nMaxPages))
+else
+  term.setTextColor(nGreenColor)
+  print(("Printed %s posters!"):format(nPrinted))
+end
+term.setTextColor(startTColor)

--- a/src/main/resources/data/computercraft/lua/rom/programs/poster.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/poster.lua
@@ -188,10 +188,10 @@ term.setTextColor(colors.lightGray)
 print("Now printing:")
 
 local _, ypos = term.getCursorPos()
-local width, _ = term.getSize()
+local width, height = term.getSize()
 
 -- Move everything up for enough space
-if ypos > 16 then
+if ypos > height-3 then
   term.scroll(4)
   ypos = 15
 end
@@ -222,12 +222,12 @@ for i, data in ipairs(posters) do
   printRow("Name: ", (data.label or "???"):sub(1, width-6))
   
   term.setCursorPos(1, ypos+1)
-  printRow("Status: ", ("   0%% : %"..numDigits.."d / %"..numDigits.."d"):format(printed, maxPages), (" (x%d)       "):format(count))
+  printRow("Status: ", ("  0%% : %"..numDigits.."d / %"..numDigits.."d"):format(printed, maxPages), (" (x%d)       "):format(count))
 
 
   local cur, max = printer.getInkLevel()
   term.setCursorPos(1, ypos+2)
-  printRow("Ink: ", (" %5.f%%   "):format(math.floor(100/max*cur)))
+  printRow("Ink: ", ("%3d%%   "):format(math.floor(100/max*cur)))
   
   -- Status and Ink level
   while true do
@@ -242,7 +242,7 @@ for i, data in ipairs(posters) do
       end
 
       term.setCursorPos(1, ypos+1)
-      printRow("Status: ", (" %3d%% : %"..numDigits.."d / %"..numDigits.."d "):format(progress, printed, maxPages), ("(x%d)       "):format(count))
+      printRow("Status: ", ("%3d%% : %"..numDigits.."d / %"..numDigits.."d "):format(progress, printed, maxPages), ("(x%d)       "):format(count))
       if currentPage >= count then
         break
       end

--- a/src/main/resources/data/computercraft/lua/rom/programs/poster.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/poster.lua
@@ -210,10 +210,11 @@ end
 -- Loop to print all selected posters
 local printed = 0
 local maxPages = #posters*count
+local numDigits = math.floor(math.log10(maxPages))+1
 local terminated = false
 
 for i, data in ipairs(posters) do
-  local cur = 0
+  local currentPage = 0
   if terminated then break end
   commitPrint(data)
   
@@ -221,12 +222,12 @@ for i, data in ipairs(posters) do
   printRow("Name: ", (data.label or "???"):sub(1, width-6))
   
   term.setCursorPos(1, ypos+1)
-  printRow("Status: ", (" %d%% : %d / %d "):format(0, printed, maxPages), (" (x%d)       "):format(count))
+  printRow("Status: ", ("   0%% : %"..numDigits.."d / %"..numDigits.."d"):format(printed, maxPages), (" (x%d)       "):format(count))
 
 
   local cur, max = printer.getInkLevel()
   term.setCursorPos(1, ypos+2)
-  printRow("Ink: ", (" %d%%   "):format(math.floor(100/max*cur)))
+  printRow("Ink: ", (" %5.f%%   "):format(math.floor(100/max*cur)))
   
   -- Status and Ink level
   while true do
@@ -237,13 +238,12 @@ for i, data in ipairs(posters) do
       
       if progress >= 100 then
         printed = printed+1
-        cur = cur+1
+        currentPage = currentPage+1
       end
 
       term.setCursorPos(1, ypos+1)
-      printRow("Status: ", (" %d%% : %d / %d "):format(progress, printed, maxPages), (" (x%d)       "):format(count))
-      
-      if cur >= count then
+      printRow("Status: ", (" %3d%% : %"..numDigits.."d / %"..numDigits.."d "):format(progress, printed, maxPages), ("(x%d)       "):format(count))
+      if currentPage >= count then
         break
       end
     elseif e == "terminate" then


### PR DESCRIPTION
This pull request adds support for .2dja files, a file format used by the community to simplify the printing of large signs.

While maintaining compatibility, two optional numbers can now be appended to the syntax to indicate the interval of pages to be used if a .2dja file is provided. Or a single specific page.

Additionally, the status text has been updated.
This commit also ensures that the program is now compatible with normal PCs that don't support all colors.

Finally, comments and style changes have been included for improved readability.

I tried to ensure that the program was as robust and secure as possible.