### PR TITLE
fix: allow both printer types to be used in inventory operations

### DIFF
--- a/src/main/kotlin/io/sc3/peripherals/posters/printer/PosterPrinterPeripheral.kt
+++ b/src/main/kotlin/io/sc3/peripherals/posters/printer/PosterPrinterPeripheral.kt
@@ -15,6 +15,7 @@ import java.util.*
 
 class PosterPrinterPeripheral(val be: PosterPrinterBlockEntity) : IPeripheral {
   override fun getType() = "poster_printer"
+  override fun getTarget() = be
 
   @LuaFunction(mainThread = true)
   fun reset() {

--- a/src/main/kotlin/io/sc3/peripherals/prints/printer/PrinterPeripheral.kt
+++ b/src/main/kotlin/io/sc3/peripherals/prints/printer/PrinterPeripheral.kt
@@ -19,6 +19,7 @@ import java.util.*
 
 class PrinterPeripheral(val be: PrinterBlockEntity) : IPeripheral {
   override fun getType() = "3d_printer"
+  override fun getTarget() = be
 
   @LuaFunction(mainThread = true)
   fun reset() {


### PR DESCRIPTION
Implementing IPeripheral::getTarget allows other inventory peripherals to detect the blockentity responsible for the printers' inventories. Fixes #4 (the second part; the first part should be considered an upstream limitation IMO, see cc-tweaked/CC-Tweaked#633 ). I'm not sure why CC doesn't do this (implementing getTarget) itself though.

![image](https://github.com/SwitchCraftCC/sc-peripherals/assets/24967425/4cf81809-1dd8-4bde-9923-3da11d4b593f)
Players no longer need to build hopper monstrosities:
<img width="1280" alt="image" src="https://github.com/SwitchCraftCC/sc-peripherals/assets/24967425/5dcea845-9c21-4c78-a87a-aeb9b3bed4f2">

