### PR TITLE
feat: allow prints to determine whether they light up depending on state

### DIFF
--- a/src/main/kotlin/io/sc3/peripherals/prints/PrintBlock.kt
+++ b/src/main/kotlin/io/sc3/peripherals/prints/PrintBlock.kt
@@ -15,7 +15,6 @@ import net.minecraft.entity.LivingEntity
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.ItemPlacementContext
 import net.minecraft.item.ItemStack
-import net.minecraft.loot.context.LootContext
 import net.minecraft.loot.context.LootContextParameterSet
 import net.minecraft.loot.context.LootContextParameters
 import net.minecraft.server.world.ServerWorld
@@ -133,7 +132,7 @@ class PrintBlock(settings: Settings) : BaseBlockWithEntity(settings), Waterlogga
     if (!stack.isOf(ModItems.print)) return 0
 
     val data = PrintItem.printData(ctx.stack)
-    return if (data?.lightWhenOff==true) data?.lightLevel ?: 0 else 0
+    return if (data?.lightWhenOff == true) data.lightLevel else 0
   }
 
   // Redstone

--- a/src/main/kotlin/io/sc3/peripherals/prints/PrintBlock.kt
+++ b/src/main/kotlin/io/sc3/peripherals/prints/PrintBlock.kt
@@ -133,7 +133,7 @@ class PrintBlock(settings: Settings) : BaseBlockWithEntity(settings), Waterlogga
     if (!stack.isOf(ModItems.print)) return 0
 
     val data = PrintItem.printData(ctx.stack)
-    return data?.lightLevel ?: 0
+    return if (data?.lightWhenOff==true) data?.lightLevel ?: 0 else 0
   }
 
   // Redstone

--- a/src/main/kotlin/io/sc3/peripherals/prints/PrintBlockEntity.kt
+++ b/src/main/kotlin/io/sc3/peripherals/prints/PrintBlockEntity.kt
@@ -62,16 +62,14 @@ class PrintBlockEntity(
     val world = world ?: return
     val block = cachedState.block as? PrintBlock ?: return
 
-    var luminance = data?.lightLevel ?: 0
-    if (!on) {
-      // if we're turning on, and we don't want light when we're on, turn off the light
-      if (!lightWhenOn) luminance = 0
-    } else {
-      // conversely, if we're turning off, and we don't want light when we're off, turn off the light
-      if (!lightWhenOff) luminance = 0
-    }
+    val hasLight = if (on) lightWhenOn else lightWhenOff
+    val luminance = if (hasLight) data?.lightLevel ?: 0 else 0
 
-    world.setBlockState(pos, cachedState.with(PrintBlock.on, !on).with(PrintBlock.luminance, luminance), Block.NOTIFY_ALL)
+    val newState = cachedState
+      .with(PrintBlock.on, !on)
+      .with(PrintBlock.luminance, luminance)
+    world.setBlockState(pos, newState, Block.NOTIFY_ALL)
+
     if (data?.isQuiet != true) {
       world.playSound(null, pos, SoundEvents.BLOCK_LEVER_CLICK, SoundCategory.BLOCKS, 0.3f, if (on) 0.6f else 0.3f)
     }

--- a/src/main/kotlin/io/sc3/peripherals/prints/PrintData.kt
+++ b/src/main/kotlin/io/sc3/peripherals/prints/PrintData.kt
@@ -20,6 +20,8 @@ data class PrintData(
   var isButton: Boolean = false,
   var collideWhenOn: Boolean = true,
   var collideWhenOff: Boolean = true,
+  var lightWhenOn: Boolean = true,
+  var lightWhenOff: Boolean = true,
 
   var lightLevel: Int = 0,
   var redstoneLevel: Int = 0,
@@ -72,6 +74,8 @@ data class PrintData(
     nbt.putBoolean("isButton", isButton)
     nbt.putBoolean("collideWhenOn", collideWhenOn)
     nbt.putBoolean("collideWhenOff", collideWhenOff)
+    nbt.putBoolean("lightWhenOn", lightWhenOn)
+    nbt.putBoolean("lightWhenOff", lightWhenOff)
     nbt.putInt("lightLevel", lightLevel)
     nbt.putInt("redstoneLevel", redstoneLevel)
     nbt.putBoolean("isBeaconBlock", isBeaconBlock)
@@ -91,6 +95,8 @@ data class PrintData(
       isButton = nbt.getBoolean("isButton"),
       collideWhenOn = nbt.getBoolean("collideWhenOn"),
       collideWhenOff = nbt.getBoolean("collideWhenOff"),
+      lightWhenOn = nbt.getBoolean("lightWhenOn"),
+      lightWhenOff = nbt.getBoolean("lightWhenOff"),
       lightLevel = nbt.getInt("lightLevel"),
       redstoneLevel = nbt.getInt("redstoneLevel"),
       isBeaconBlock = nbt.getBoolean("isBeaconBlock"),

--- a/src/main/kotlin/io/sc3/peripherals/prints/printer/PrinterPeripheral.kt
+++ b/src/main/kotlin/io/sc3/peripherals/prints/printer/PrinterPeripheral.kt
@@ -82,6 +82,16 @@ class PrinterPeripheral(val be: PrinterBlockEntity) : InventoryPeripheral(be) {
     be.data.collideWhenOn = collideWhenOn
     be.dataUpdated()
   }
+
+  @LuaFunction(mainThread = true)
+  fun getStateLighting(): MethodResult = of(be.data.lightWhenOff, be.data.lightWhenOn)
+
+  @LuaFunction(mainThread = true)
+  fun setStateLighting(lightWhenOff: Boolean, lightWhenOn: Boolean) {
+    be.data.lightWhenOff = lightWhenOff
+    be.data.lightWhenOn = lightWhenOn
+    be.dataUpdated()
+  }
   
   @LuaFunction(mainThread = true)
   fun getShapeCount(): MethodResult = of(be.data.shapesOff.size, be.data.shapesOn.size)

--- a/src/main/resources/data/computercraft/lua/rom/programs/print3d.lua
+++ b/src/main/resources/data/computercraft/lua/rom/programs/print3d.lua
@@ -131,6 +131,7 @@ local function commitPrint(data)
   if data.tooltip then printer.setTooltip(data.tooltip) end
   printer.setButtonMode(data.isButton or false)
   printer.setCollidable(data.collideWhenOff ~= false, data.collideWhenOn ~= false)
+  printer.setStateLighting(data.lightWhenOff ~= false, data.lightWhenOn ~= false)
   printer.setRedstoneLevel(data.redstoneLevel or 0)
   printer.setLightLevel(data.lightLevel or 0)
 


### PR DESCRIPTION
Adds the `getStateLighting` and `setStateLighting` functions to the printer peripheral, allowing to toggle the print's light level based on whether the print is on or off.

Also adds `lightWhenOff` and `lightWhenOn` to the 3dj format as read by the `print3d` program (cf. `collideWhenOff`/`collideWhenOn`).

I'm not too attached to the `getStateLighting`/`setStateLighting` name, that's just the best I could come up with when I was writing the implementation.